### PR TITLE
[FIX] Problem with the module Object Merge

### DIFF
--- a/account_easy_reconcile/base_reconciliation.py
+++ b/account_easy_reconcile/base_reconciliation.py
@@ -34,8 +34,6 @@ class EasyReconcileBase(orm.AbstractModel):
     _columns = {
         'account_id': fields.many2one(
             'account.account', 'Account', required=True),
-        'partner_ids': fields.many2many(
-            'res.partner', string="Restrict on partners"),
         # other columns are inherited from easy.reconcile.options
     }
 


### PR DESCRIPTION
This field was wrong declared, and the module Object Merge did not work okay, when try to merge two or more partners it crashed
